### PR TITLE
Two bug fixes 

### DIFF
--- a/data_pipeline/marshall_osm_data.py
+++ b/data_pipeline/marshall_osm_data.py
@@ -217,6 +217,8 @@ class OSMDataNormalizer:
     index = 0
     for folder, subs, files in os.walk(rootdir):
       for filename in files:
+        if not filename.endswith('.json'):
+            continue
         has_ways = False
         with open(os.path.join(folder, filename), 'r') as src:
           linestrings = self.linestrings_for_vector_tile(src)
@@ -263,6 +265,8 @@ class OSMDataNormalizer:
     index = 0
     for folder, subs, files in os.walk(rootdir):
       for filename in files:
+        if not filename.endswith('.jpg'):
+            continue
         tile = self.tile_for_folder_and_filename(folder, filename, rootdir)
         image_filename = os.path.join(folder, filename)
         with open(image_filename, 'rb') as img_file:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-numpy==1.8
-pillow
+numpy==1.10.4
+Pillow==3.1.1
 https://storage.googleapis.com/tensorflow/mac/tensorflow-0.7.1-cp35-none-any.whl


### PR DESCRIPTION
1. Pinned requirement versions, closes #2.
2. Skipping non-matching filenames to prevent `.DS_Store` reads.
