### PR TITLE
requirements.txt refactor

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,23 +1,14 @@
-# process images into matrrices for Tensorflow
+boto3==1.3.1
+GDAL==2.1.0
+h5py==2.6.0
 numpy==1.11.0
-Pillow==3.1.1
-jupyter==1.0.0
-
-# download images from S3
-boto3==1.3.0
-
-GDAL==2.0.1
+Pillow==3.2.0
+pyosmium==2.6.0
 pyproj==1.9.5.1
+requests==2.10.0
+s3cmd==1.6.1
+Shapely==1.5.15
+tensorflow==0.8.0
 
-# the recommended Tensorflow binary on linux, CPU only
-https://storage.googleapis.com/tensorflow/linux/cpu/tensorflow-0.8.0-cp27-none-linux_x86_64.whl
-
-# the recommended Tensorflow binary for python 2 on linux, GPU
-# http://storage.googleapis.com/tensorflow/linux/gpu/tensorflow-0.8.0-cp27-none-linux_x86_64.whl
-
-shapely
-
-# trying this out for the cifar10 network
-git+https://github.com/tflearn/tflearn.git
-
-h5py
+# tflearn, pinned to an arbitrary commit
+git+https://github.com/tflearn/tflearn.git@4fef666

--- a/requirements_base.txt
+++ b/requirements_base.txt
@@ -8,7 +8,6 @@ pyproj==1.9.5.1
 requests==2.10.0
 s3cmd==1.6.1
 Shapely==1.5.15
-tensorflow==0.8.0
 
 # tflearn, pinned to an arbitrary commit
 git+https://github.com/tflearn/tflearn.git@4fef666

--- a/requirements_base.txt
+++ b/requirements_base.txt
@@ -1,6 +1,7 @@
 boto3==1.3.1
 GDAL==2.1.0
 h5py==2.6.0
+jupyter==1.0.0
 numpy==1.11.0
 Pillow==3.2.0
 pyosmium==2.6.0

--- a/requirements_cpu.txt
+++ b/requirements_cpu.txt
@@ -1,0 +1,3 @@
+-r requirements_base.txt
+
+https://storage.googleapis.com/tensorflow/linux/cpu/tensorflow-0.8.0-cp27-none-linux_x86_64.whl

--- a/requirements_gpu.txt
+++ b/requirements_gpu.txt
@@ -1,0 +1,3 @@
+-r requirements_base.txt
+
+https://storage.googleapis.com/tensorflow/linux/gpu/tensorflow-0.8.0-cp27-none-linux_x86_64.whl


### PR DESCRIPTION
I refactored requirements.txt so that it can be installed with a single `pip install --upgrade -r requirements_[cpu,gpu].txt` command for the different environments we have.
- pulled the Tensorflow CPU and GPU binaries into separate `requirements_cpu.txt` and `requirements_gpu.txt` files which inherit from `requirements_base.txt`, so you just pick either cpu or gpu to install
- pinned versions for shapely, tflearn, and h5py
- added missing entries for pyosmium, requests, and s3cmd
