### PR TITLE
Fixes dockerfile issue with Protobuf submodule

### DIFF
--- a/Dockerfile.devel-gpu
+++ b/Dockerfile.devel-gpu
@@ -151,9 +151,7 @@ RUN mkdir /bazel && \
     rm -f /bazel/bazel-$BAZEL_VERSION-installer-linux-x86_64.sh
 
 # Download and build TensorFlow.
-RUN git clone --recursive https://github.com/tensorflow/tensorflow.git && \
-    cd tensorflow && \
-    git checkout r0.8
+RUN git clone -b r0.8 --recursive https://github.com/tensorflow/tensorflow.git
 WORKDIR /tensorflow
 
 # Set up CUDA variables


### PR DESCRIPTION
Fixes the issue per this comment: https://github.com/tensorflow/tensorflow/issues/2790
Note: the -b r0.8 must be in the clone command or the submodule will not clone properly.
