### PR TITLE
Adjust window opening target

### DIFF
--- a/deeposm.org/website/templates/view_error.html
+++ b/deeposm.org/website/templates/view_error.html
@@ -29,7 +29,7 @@
                 Likely Error {% widthratio error.certainty 1 85 %}%
           </td>
           <td>
-             <a class="btn btn-success" target=_new href=https://www.openstreetmap.org/edit#map=18/{{center.0}}/{{center.1}}
+             <a class="btn btn-success" target="_blank" href=https://www.openstreetmap.org/edit#map=18/{{center.0}}/{{center.1}}
 >Fix in OpenStreetMap</a>
           </td>
           <td>


### PR DESCRIPTION
When you edit multiple errors and choose to 'fix in openstreetmap', they all try to open in the same ID instance.

This isn't too great for bulk workflow (open 10 errors, assess false positives, edit the rest by opening in new tab)
